### PR TITLE
fix error when isReady called but HomegearWS constructor not called

### DIFF
--- a/homegear-ws-0.0.1.js
+++ b/homegear-ws-0.0.1.js
@@ -253,7 +253,7 @@ HomegearWS.prototype.removePeer = function(id) {
 }
 
 HomegearWS.prototype.isReady = function() {
-	return this.server.OPEN && this.client.OPEN && this.serverAuthenticated && this.clientAuthenticated;
+	return this.server && this.server.OPEN && this.client && this.client.OPEN && this.serverAuthenticated && this.clientAuthenticated;
 }
 
 HomegearWS.prototype.subscribePeers = function() {


### PR DESCRIPTION
because `isReady()` it is a prototype method, it should work without calling the constructor first.
